### PR TITLE
Update PROJ-Info.plist with AdMob key for Stencyl 4.0.3

### DIFF
--- a/templates/iphone/PROJ/PROJ-Info.plist
+++ b/templates/iphone/PROJ/PROJ-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	::if (ENV_ADMOB_APP_ID != null)::<key>GADApplicationIdentifier</key>
+	<string>::ENV_ADMOB_APP_ID::</string>::end::
 	::if ENV_APPLOVIN_ENABLED::<key>AppLovinSdkKey</key>
 	<string>::ENV_APPLOVIN_SDKKEY::</string>::end::
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
This is necessary in Stencyl 4.0.3 to avoid a crash when AdMob is enabled.